### PR TITLE
chore: use `is_some_and` for file ext check

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -29,7 +29,7 @@ impl TerraformProject {
             let path = entry.path();
 
             if path.is_file() {
-                if path.extension().map_or(false, |ext| ext == "tf")
+                if path.extension().is_some_and(|ext| ext == "tf")
                     && !path.to_string_lossy().contains("/.terraform/")
                 {
                     tf_files.push(path);


### PR DESCRIPTION

```
error: this `map_or` is redundant
  --> src/project.rs:32:20
   |
32 |                 if path.extension().map_or(false, |ext| ext == "tf")
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_some_and instead: `path.extension().is_some_and(|ext| ext == "tf")`
   |
```

for #6 and #7